### PR TITLE
ci: discard using default cf env vars

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build-pr:
+    name: Build
     runs-on: ubuntu-latest
     env:
       HUGO_VERSION: '0.131.0'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,4 +1,4 @@
-name: Build and Publish
+name: Build, Publish, and Deploy
 
 on:
   push:
@@ -14,6 +14,7 @@ env:
 
 jobs:
   build:
+    name: Build and Publish to Docker Hub
     runs-on: ubuntu-latest
     steps:
     - name: Check out repository code
@@ -48,9 +49,8 @@ jobs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
   deploy:
+    name: Deploy to Cloudflare Pages
     runs-on: ubuntu-latest
-    env:
-      HUGO_VERSION: '0.131.0'
     steps:
     - name: Check out repository code
       uses: actions/checkout@v4
@@ -63,6 +63,9 @@ jobs:
         extended: true
     - name: Build
       run: hugo --minify --gc
+      env:
+        HUGO_PARAMS_VERSION: ${{ github.ref_name }}
+        HUGO_PARAMS_COMMIT: ${{ github.sha }}
     - name: Publish to Cloudflare Pages
       uses: cloudflare/wrangler-action@v3
       with:

--- a/config/_default/hugo.yaml
+++ b/config/_default/hugo.yaml
@@ -22,6 +22,7 @@ params:
     date_format: '2006-01-02'
     show_description: true
   version: 'dev'
+  commit: ''
 security:
   funcs:
     getenv:

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,12 +2,10 @@
   {{ if .Site.Copyright }}
   <div>&copy; 2014-{{ now.Format "2006" }} {{ .Site.Copyright }}</div>
   {{ end }}
-  {{ if getenv "CF_PAGES_BRANCH" }}
-  <div>Version {{ getenv "CF_PAGES_BRANCH" }}</div>
-  {{ else if .Site.Params.Version }}
+  {{ if .Site.Params.Version }}
   <div>Version {{ .Site.Params.Version }}</div>
   {{ end }}
-  {{ if getenv "CF_PAGES_COMMIT_SHA" }}
-  <div>Build {{ slicestr (getenv "CF_PAGES_COMMIT_SHA") 0 8 }}</div>
+  {{ if .Site.Params.Commit }}
+  <div>Build {{ slicestr .Site.Params.Commit 0 8 }}</div>
   {{end}}
 </footer>


### PR DESCRIPTION
Now that both the version and commit id strings will be passed in as environment variables during workflow execution.