### PR TITLE
fix(lint): pin mdl to 0.17.0 to avoid regression from 0.18.0

### DIFF
--- a/Dockerfile.lint
+++ b/Dockerfile.lint
@@ -1,5 +1,5 @@
 FROM ruby:3.3.4-alpine
-RUN gem install mdl
+RUN gem install mdl -v 0.17.0
 COPY . /app
 WORKDIR /app
 ENTRYPOINT ["mdl"]


### PR DESCRIPTION
Due to markdownlint/markdownlint#605, we have no choice but to fallback to 0.17.0.